### PR TITLE
Fix unit tests for Chef 12.5

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,8 +12,6 @@ end
 
 group :test do
   gem 'rake'
-  gem 'cane'
-  gem 'countloc'
   gem 'rubocop'
   gem 'foodcritic'
   gem 'rspec', '>= 3'

--- a/Rakefile
+++ b/Rakefile
@@ -4,21 +4,12 @@ require 'rubygems'
 require 'English'
 require 'bundler/setup'
 require 'rubocop/rake_task'
-require 'cane/rake_task'
 require 'rspec/core/rake_task'
 require 'foodcritic'
 require 'kitchen/rake_tasks'
 require 'stove/rake_task'
 
-Cane::RakeTask.new
-
 RuboCop::RakeTask.new
-
-desc 'Display LOC stats'
-task :loc do
-  puts "\n## LOC Stats"
-  Kernel.system 'countloc -r .'
-end
 
 FoodCritic::Rake::LintTask.new do |f|
   f.options = { fail_tags: %w(any) }
@@ -30,4 +21,4 @@ Kitchen::RakeTasks.new
 
 Stove::RakeTask.new
 
-task default: %w(cane rubocop loc foodcritic spec)
+task default: %w(rubocop foodcritic spec)

--- a/circle.yml
+++ b/circle.yml
@@ -8,6 +8,8 @@ dependencies:
   pre:
     - rvm install 2.0.0-p645
   override:
+    - gem install -V berkshelf
+    - rvm-exec 2.0.0-p645 gem install -V berkshelf
     - bundle install --without=development integration
     - rvm-exec 2.0.0-p645 bundle install --without=development integration
   cache_directories:

--- a/spec/libraries/provider_x2go_client_app_debian_spec.rb
+++ b/spec/libraries/provider_x2go_client_app_debian_spec.rb
@@ -5,8 +5,9 @@ require_relative '../../libraries/provider_x2go_client_app_debian'
 
 describe Chef::Provider::X2goClientApp::Debian do
   let(:name) { 'default' }
-  let(:new_resource) { Chef::Resource::X2goClientApp.new(name, nil) }
-  let(:provider) { described_class.new(new_resource, nil) }
+  let(:run_context) { ChefSpec::SoloRunner.new.converge.run_context }
+  let(:new_resource) { Chef::Resource::X2goClientApp.new(name, run_context) }
+  let(:provider) { described_class.new(new_resource, run_context) }
 
   describe '.provides?' do
     let(:platform) { nil }

--- a/spec/libraries/provider_x2go_client_app_fedora_spec.rb
+++ b/spec/libraries/provider_x2go_client_app_fedora_spec.rb
@@ -5,8 +5,9 @@ require_relative '../../libraries/provider_x2go_client_app_fedora'
 
 describe Chef::Provider::X2goClientApp::Fedora do
   let(:name) { 'default' }
-  let(:new_resource) { Chef::Resource::X2goClientApp.new(name, nil) }
-  let(:provider) { described_class.new(new_resource, nil) }
+  let(:run_context) { ChefSpec::SoloRunner.new.converge.run_context }
+  let(:new_resource) { Chef::Resource::X2goClientApp.new(name, run_context) }
+  let(:provider) { described_class.new(new_resource, run_context) }
 
   describe '.provides?' do
     let(:platform) { nil }

--- a/spec/libraries/provider_x2go_client_app_mac_os_x_spec.rb
+++ b/spec/libraries/provider_x2go_client_app_mac_os_x_spec.rb
@@ -5,8 +5,9 @@ require_relative '../../libraries/provider_x2go_client_app_mac_os_x'
 
 describe Chef::Provider::X2goClientApp::MacOsX do
   let(:name) { 'default' }
-  let(:new_resource) { Chef::Resource::X2goClientApp.new(name, nil) }
-  let(:provider) { described_class.new(new_resource, nil) }
+  let(:run_context) { ChefSpec::SoloRunner.new.converge.run_context }
+  let(:new_resource) { Chef::Resource::X2goClientApp.new(name, run_context) }
+  let(:provider) { described_class.new(new_resource, run_context) }
 
   describe 'PATH' do
     it 'returns the correct application path' do

--- a/spec/libraries/provider_x2go_client_app_rhel_spec.rb
+++ b/spec/libraries/provider_x2go_client_app_rhel_spec.rb
@@ -5,8 +5,9 @@ require_relative '../../libraries/provider_x2go_client_app_rhel'
 
 describe Chef::Provider::X2goClientApp::Rhel do
   let(:name) { 'default' }
-  let(:new_resource) { Chef::Resource::X2goClientApp.new(name, nil) }
-  let(:provider) { described_class.new(new_resource, nil) }
+  let(:run_context) { ChefSpec::SoloRunner.new.converge.run_context }
+  let(:new_resource) { Chef::Resource::X2goClientApp.new(name, run_context) }
+  let(:provider) { described_class.new(new_resource, run_context) }
 
   describe '.provides?' do
     let(:platform) { nil }

--- a/spec/libraries/provider_x2go_client_app_spec.rb
+++ b/spec/libraries/provider_x2go_client_app_spec.rb
@@ -5,8 +5,9 @@ require_relative '../../libraries/provider_x2go_client_app'
 
 describe Chef::Provider::X2goClientApp do
   let(:name) { 'default' }
-  let(:new_resource) { Chef::Resource::X2goClientApp.new(name, nil) }
-  let(:provider) { described_class.new(new_resource, nil) }
+  let(:run_context) { ChefSpec::SoloRunner.new.converge.run_context }
+  let(:new_resource) { Chef::Resource::X2goClientApp.new(name, run_context) }
+  let(:provider) { described_class.new(new_resource, run_context) }
 
   describe '#whyrun_supported?' do
     it 'returns true' do

--- a/spec/libraries/provider_x2go_client_app_ubuntu_spec.rb
+++ b/spec/libraries/provider_x2go_client_app_ubuntu_spec.rb
@@ -5,8 +5,9 @@ require_relative '../../libraries/provider_x2go_client_app_ubuntu'
 
 describe Chef::Provider::X2goClientApp::Ubuntu do
   let(:name) { 'default' }
-  let(:new_resource) { Chef::Resource::X2goClientApp.new(name, nil) }
-  let(:provider) { described_class.new(new_resource, nil) }
+  let(:run_context) { ChefSpec::SoloRunner.new.converge.run_context }
+  let(:new_resource) { Chef::Resource::X2goClientApp.new(name, run_context) }
+  let(:provider) { described_class.new(new_resource, run_context) }
 
   describe '.provides?' do
     let(:platform) { nil }

--- a/spec/libraries/provider_x2go_client_app_windows_spec.rb
+++ b/spec/libraries/provider_x2go_client_app_windows_spec.rb
@@ -5,8 +5,9 @@ require_relative '../../libraries/provider_x2go_client_app_windows'
 
 describe Chef::Provider::X2goClientApp::Windows do
   let(:name) { 'default' }
-  let(:new_resource) { Chef::Resource::X2goClientApp.new(name, nil) }
-  let(:provider) { described_class.new(new_resource, nil) }
+  let(:run_context) { ChefSpec::SoloRunner.new.converge.run_context }
+  let(:new_resource) { Chef::Resource::X2goClientApp.new(name, run_context) }
+  let(:provider) { described_class.new(new_resource, run_context) }
 
   describe 'PATH' do
     it 'returns the correct application path' do

--- a/spec/libraries/provider_x2go_client_spec.rb
+++ b/spec/libraries/provider_x2go_client_spec.rb
@@ -5,8 +5,9 @@ require_relative '../../libraries/provider_x2go_client'
 
 describe Chef::Provider::X2goClient do
   let(:name) { 'default' }
-  let(:new_resource) { Chef::Resource::X2goClient.new(name, nil) }
-  let(:provider) { described_class.new(new_resource, nil) }
+  let(:run_context) { ChefSpec::SoloRunner.new.converge.run_context }
+  let(:new_resource) { Chef::Resource::X2goClient.new(name, run_context) }
+  let(:provider) { described_class.new(new_resource, run_context) }
 
   describe '.provides?' do
     let(:platform) { nil }


### PR DESCRIPTION
As of 12.5, `Chef::Provider.new` no longer accepts `nil` as a run_context.